### PR TITLE
Sql migration

### DIFF
--- a/migrations/000001_create_users_table.down.sql
+++ b/migrations/000001_create_users_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS users;

--- a/migrations/000001_create_users_table.up.sql
+++ b/migrations/000001_create_users_table.up.sql
@@ -1,0 +1,9 @@
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE TABLE users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    username TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/migrations/000002_create_conversations_table.down.sql
+++ b/migrations/000002_create_conversations_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS conversations;

--- a/migrations/000002_create_conversations_table.up.sql
+++ b/migrations/000002_create_conversations_table.up.sql
@@ -1,0 +1,8 @@
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE TABLE conversations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    is_public BOOLEAN NOT NULL,
+    name TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT now()
+);

--- a/migrations/000003_create_conversation_members.down.sql
+++ b/migrations/000003_create_conversation_members.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS conversation_members

--- a/migrations/000003_create_conversation_members.up.sql
+++ b/migrations/000003_create_conversation_members.up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE conversation_members (
+	user_id UUID NOT NULL,
+	conversation_id UUID NOT NULL,
+	joined_at TIMESTAMP NOT NULL DEFAULT now(),
+
+	PRIMARY KEY (user_id, conversation_id),
+	FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+	FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
+)
+

--- a/migrations/000004_create_messages_table.down.sql
+++ b/migrations/000004_create_messages_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS messages;

--- a/migrations/000004_create_messages_table.up.sql
+++ b/migrations/000004_create_messages_table.up.sql
@@ -1,0 +1,10 @@
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE TABLE messages (
+	id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+	conversation_id UUID NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+	sender_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+	--Text only for now
+	content TEXT NOT NULL,
+	created_at TIMESTAMP NOT NULL DEFAULT now()
+);


### PR DESCRIPTION
# Add SQL migrations for users, conversations, memberships, and messages tables

## Description

This PR introduces the initial SQL migrations required to structure the database schema for the chat application. It includes the creation of the following tables:
 - `users`: stores user credentials and registration timestamps.
 - `conversations`: represents public or private chat groups.
 - `memberships` : manages the many-to-many relationship between users and conversations.*
 - `messages`: stores messages sent within conversations.

These migrations are managed using `golang-migrate`, a robust tool for tracking and applying schema changes in a consistent and repeteable way.

## Reasons to use SQL migrations

SQL migrations help ensure that:
- the database schema is version-controlled,
- changes are predictable and reversible,
- deployment across environments (dev/staging/prod) remains consistent.