### PR TITLE
Feature/register

### DIFF
--- a/internal/handlers/register.go
+++ b/internal/handlers/register.go
@@ -3,10 +3,8 @@ package handlers
 import (
 	"encoding/json"
 	"net/http"
-	""
+	"errors"
 
-	"github.com/EliasLd/gotalk-backend/internal/models"
-	"github.com/EliasLd/gotalk-backend/internal/service"
 	appErr "github.com/EliasLd/gotalk-backend/internal/service/errors"
 )
 

--- a/internal/handlers/register.go
+++ b/internal/handlers/register.go
@@ -1,0 +1,20 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/EliasLd/gotalk-backend/internal/models"
+	"github.com/EliasLd/gotalk-backend/internal/service"
+)
+
+type registerRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type registerResponse struct {
+	ID		string	`json:"id"`
+	Username	string	`json:"username"`
+	CreatedAt	string	`json:"createdAt"`
+}

--- a/internal/handlers/register.go
+++ b/internal/handlers/register.go
@@ -3,9 +3,11 @@ package handlers
 import (
 	"encoding/json"
 	"net/http"
+	""
 
 	"github.com/EliasLd/gotalk-backend/internal/models"
 	"github.com/EliasLd/gotalk-backend/internal/service"
+	appErr "github.com/EliasLd/gotalk-backend/internal/service/errors"
 )
 
 type registerRequest struct {
@@ -17,4 +19,40 @@ type registerResponse struct {
 	ID		string	`json:"id"`
 	Username	string	`json:"username"`
 	CreatedAt	string	`json:"createdAt"`
+}
+
+func (h *Handler) HandleRegister(w http.ResponseWriter, r *http.Request) {
+	var req registerRequest
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid JSON body", http.StatusBadRequest)
+		return
+	}
+	
+	user, err := h.userService.RegisterUser(r.Context(), req.Username, req.Password)
+	if err != nil {
+		switch {
+		case errors.Is(err, appErr.ErrUserAlreadyExists):
+			http.Error(w, err.Error(), http.StatusConflict)
+		case errors.Is(err, appErr.ErrPasswordTooShort),
+	    		errors.Is(err, appErr.ErrPasswordMissingDigit),
+	     		errors.Is(err, appErr.ErrPasswordMissingUpper),
+	     		errors.Is(err, appErr.ErrPasswordMissingLower),
+	     		errors.Is(err, appErr.ErrPasswordMissingSymbol):
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		default:
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	resp := registerResponse{
+		ID:		user.ID.String(),
+		Username:	user.Username,
+		CreatedAt:	user.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(resp)
 }

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -12,6 +12,7 @@ func NewRouter(handler * handlers.Handler) http.Handler {
 
 	// Public routes
 	mux.HandleFunc("/health", handlers.HealthHandler)
+	mux.HandleFunc("/register", handler.HandleRegister)
 
 	// Private routes
 	mux.Handle("/me", middleware.AuthMiddleware(http.HandlerFunc(handler.HandleGetMe)))

--- a/internal/http/router_test.go
+++ b/internal/http/router_test.go
@@ -150,3 +150,28 @@ func TestRegisterRoute_UserAlreadyExists(t *testing.T) {
 
 	defer repository.CleanUpUser(t, userID, repo)
 }
+
+func TestRegisterRoute_InvalidPassword(t *testing.T) {
+	repo := repository.SetupTest(t)
+	userService := service.NewUserService(repo)
+	handler := handlers.NewHandler(userService)
+	router := NewRouter(handler)
+
+	username := "testuser_invalid_password"
+	invalidPassword := "abc"
+
+	reqBody := `{"username":"` + username + `","password":"` + invalidPassword + `"}`
+
+	req := httptest.NewRequest("POST", "/register", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("Expected status 400 Bad Request, got %d", rr.Code)
+	}
+
+	if !strings.Contains(rr.Body.String(), "password") {
+		t.Errorf("Expected error message to mention 'password', got: %s", rr.Body.String())
+	}
+}

--- a/internal/http/router_test.go
+++ b/internal/http/router_test.go
@@ -146,15 +146,7 @@ func TestRegisterRoute_UserAlreadyExists(t *testing.T) {
 		t.Fatalf("Expected status 409 Conflict on duplicate register, got %d", secondRec.Code)
 	}
 
-	var response map[string]interface{}
-	if err := json.NewDecoder(firstRec.Body).Decode(&response); err != nil {
-		t.Fatalf("Failed to decode response: %v", err)
-	}
-
-	userID, err := uuid.Parse(response["id"].(string))
-	if err != nil {
-		t.Fatalf("Failed to parse user ID: %v", err)
-	}
+	userID := ParseUserIDFromResponse(t, firstRec.Body)
 
 	defer repository.CleanUpUser(t, userID, repo)
 }

--- a/internal/http/router_test.go
+++ b/internal/http/router_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/EliasLd/gotalk-backend/internal/handlers"
 	"github.com/EliasLd/gotalk-backend/internal/service"
 	"github.com/EliasLd/gotalk-backend/internal/repository"
+	"github.com/google/uuid"
 
 )
 
@@ -72,4 +73,46 @@ func TestGetMe_Unauthorized(t *testing.T) {
 	if !strings.Contains(rr.Body.String(), "Missing or invalid Authorization header") {
 		t.Errorf("Unexpected response body: %s", rr.Body.String())
 	}
+}
+
+func TestRegisterRoute(t *testing.T) {
+	repo := repository.SetupTest(t)
+	userService := service.NewUserService(repo)
+	handler := handlers.NewHandler(userService)
+	router := NewRouter(handler)
+
+	username := "testuser_register"
+	password := "ValidPasswd123!"
+
+	reqBody := `{"username":"` + username + `","password":"` + password + `"}`
+
+	req := httptest.NewRequest("POST", "/register", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("Expected status 201 Created, got %d", rr.Code)
+	}
+
+	var response map[string]interface{}
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if response["username"] != username {
+		t.Errorf("Expected username %s, got %v", username, response["username"])
+	}
+
+	if response["id"] == "" || response["createdAt"] == "" {
+		t.Error("Expected non-empty ID and CreatedAt fields")
+	}
+
+	userID, err := uuid.Parse(response["id"].(string))
+	if err != nil {
+		t.Fatalf("Failed to parse user ID: %v", err)
+	}
+
+	defer repository.CleanUpUser(t, userID, repo)
+
 }

--- a/internal/http/test_utils.go
+++ b/internal/http/test_utils.go
@@ -1,0 +1,36 @@
+package http
+
+import (
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+
+func ParseUserIDFromResponse(t *testing.T, body io.Reader) uuid.UUID {
+	t.Helper()
+
+	var response map[string]interface{}
+	if err := json.NewDecoder(body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response body: %v", err)
+	}
+
+	idRaw, ok := response["id"]
+	if !ok {
+		t.Fatalf("Response does not contain 'id' field")
+	}
+
+	idStr, ok := idRaw.(string)
+	if !ok {
+		t.Fatalf("Expected 'id' field to be a string, got %T", idRaw)
+	}
+
+	userID, err := uuid.Parse(idStr)
+	if err != nil {
+		t.Fatalf("Invalid UUID format: %v", err)
+	}
+
+	return userID
+}


### PR DESCRIPTION
## Feature: Register Route

### Summary
This pull request implements a public `/register` endpoint, allowing new users to create an account by providing a valid username and password. The feature includes validation, structured response formatting, error handling, and comprehensive test coverage.

### What's Included

**Endpoint: POST /register**
- Accepts a JSON body containing `username` and `password`.
- Validates password against multiple security rules (length, digit, uppercase, lowercase, symbol).
- Checks if the username is already taken.
- Returns a JSON response with `id`, `username`, and `createdAt` upon success.
- Responds with appropriate HTTP status codes:
  - `201 Created` for successful registration
  - `400 Bad Request` for invalid password
  - `409 Conflict` for duplicate usernames

**Handler Implementation**
- Introduced `HandleRegister` in the `handlers` package.
- Defined `registerRequest` and `registerResponse` structs for clear request/response schema.

**Router Integration**
- Registered `/register` as a public route in the HTTP router.

**Tests**
- `TestRegisterRoute`: verifies successful user registration.
- `TestRegisterRoute_ExistingUser`: ensures duplicate usernames are rejected.
- `TestRegisterRoute_InvalidPassword`: ensures invalid passwords are properly rejected.
- All tests include cleanup to maintain database integrity.
- Introduced a test utility to extract and parse user IDs from HTTP responses.

### Next Steps
The next milestone will be implementing the `/login` route and completing the authentication flow. This work will be handled in a dedicated `feature/login` branch.
