### PR TITLE
Feature/update user

### DIFF
--- a/internal/handlers/user_update.go
+++ b/internal/handlers/user_update.go
@@ -1,0 +1,16 @@
+package handlers
+
+import (
+	"github.com/EliasLd/gotalk-backend/internal/middleware"	
+)
+
+type UpdateUserRequest struct {
+	Username *string `json:"username,omitempty"`
+	Password *string `json:"password,omitempty"`
+}
+
+type UpdateUserResponse struct {
+	ID		string `json:"id"`
+	Username	string `json:"username"`
+	UpdatedAt	string `json:"updatedAt"`
+}

--- a/internal/handlers/user_update.go
+++ b/internal/handlers/user_update.go
@@ -1,7 +1,14 @@
 package handlers
 
 import (
-	"github.com/EliasLd/gotalk-backend/internal/middleware"	
+	"encoding/json"
+	"net/http"
+	"errors"
+
+	"github.com/EliasLd/gotalk-backend/internal/service"
+	appErr "github.com/EliasLd/gotalk-backend/internal/service/errors"
+	"github.com/EliasLd/gotalk-backend/internal/http/middleware"
+	"github.com/google/uuid"
 )
 
 type UpdateUserRequest struct {
@@ -13,4 +20,58 @@ type UpdateUserResponse struct {
 	ID		string `json:"id"`
 	Username	string `json:"username"`
 	UpdatedAt	string `json:"updatedAt"`
+}
+
+// User to gracefully handle user data updates
+func (h *Handler) HandleUpdateMe(w http.ResponseWriter, r *http.Request) {
+	userID, ok := middleware.UserIDFromContext(r.Context())
+	if !ok {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var req UpdateUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if req.Username == nil && req.Password == nil {
+		http.Error(w, "At least one field (username of password) must be provided", http.StatusBadRequest)
+		return
+	}
+	
+	userUUID, err := uuid.Parse(userID)
+	if err != nil {
+		http.Error(w, "Invalid user ID", http.StatusBadRequest)
+	}
+	updatedUser, err := h.userService.UpdateUser(r.Context(), userUUID, service.UpdateUserInput { 
+		Username: req.Username,
+		Password: req.Password,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, appErr.ErrUserNotFound):
+			http.Error(w, "User not found", http.StatusNotFound)
+		case errors.Is(err, appErr.ErrPasswordTooShort),
+	    		errors.Is(err, appErr.ErrPasswordMissingDigit),
+	     		errors.Is(err, appErr.ErrPasswordMissingUpper),
+	     		errors.Is(err, appErr.ErrPasswordMissingLower),
+	     		errors.Is(err, appErr.ErrPasswordMissingSymbol),
+			errors.Is(err, appErr.ErrPasswordHashingFailed):
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		default:
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	resp := UpdateUserResponse {
+		ID:		updatedUser.ID.String(),
+		Username:	updatedUser.Username,
+		UpdatedAt:	updatedUser.UpdatedAt.Format("2006-01-02T15:04:05z07:00"),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
 }

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -17,6 +17,7 @@ func NewRouter(handler * handlers.Handler) http.Handler {
 
 	// Private routes
 	mux.Handle("/me", middleware.AuthMiddleware(http.HandlerFunc(handler.HandleGetMe)))
+	mux.Handle("/me/update", middleware.AuthMiddleware(http.HandlerFunc(handler.HandleUpdateMe)))
 
 	return mux
 }


### PR DESCRIPTION
# Feature: User Profile Update (/me/update)

## Summary
This pull request introduces the ability for authenticated users to update their own profile information via a dedicated `/me/update` endpoint. Users can modify either their username or password while ensuring validation rules are respected.

## What's Included
Endpoint: PUT /me/update
- Allows authenticated users to update their username and/or password.
- Requires a valid JWT token in the Authorization header.
- Returns updated user information (id, username, updatedAt) on success.
- Returns appropriate HTTP errors for invalid input, missing fields, or unauthorized access.

## Handler & Structs
- `HandleUpdateMe` in `internal/handlers/user_update.go` implements the business logic for profile updates.
- Request and response structs (`UpdateUserRequest`, `UpdateUserResponse`) were added to standardize API payloads.

## Router
- The route `/me/update` was added to `internal/http/router.go` with the authentication middleware applied.

## Tests
- Success path tests for updating username and password were added in `internal/http/router_test.go`.
- Ensures that the updated values are correctly reflected in the API response.
- Verifies proper handling of authentication and request payloads.

This feature completes the user profile management functionality alongside existing registration and login endpoints.
